### PR TITLE
Add cloud services links

### DIFF
--- a/docs/services/services.md
+++ b/docs/services/services.md
@@ -5,5 +5,5 @@ sidebar_position: 1
 
 Details about the existing CIROH Cloud Services and how to get access to it.
 
-- AWS Cloud Services
-- 2i2c JupyterHub (GCP) Cloud Services
+- [AWS Cloud Services](https://docs.ciroh.org/docs/services/aws/)
+- [2i2c JupyterHub (GCP) Cloud Services](https://docs.ciroh.org/docs/services/google/)


### PR DESCRIPTION
The main cloud service page has text listing the cloud services we support so far. This will help show the connection to the pages with more detail. 
Before merging:
- [x] Check for a way to do this with relative links, so that changes to the site layout are less brittle.