### PR TITLE
Add Community NextGen tab and stub

### DIFF
--- a/docs/products/tools/communitynextgen/_category_.json
+++ b/docs/products/tools/communitynextgen/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Community NextGen",
+    "position": 1
+}

--- a/docs/products/tools/communitynextgen/communitynextgen.md
+++ b/docs/products/tools/communitynextgen/communitynextgen.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 1
+---
+
+# CIROH Community NextGen
+
+The NextGen Water Resources Modeling Framework
+
+


### PR DESCRIPTION
This pull request is the beginning of making a landing page where the Community NextGen documentation can live on the CIROH github site. At this point, it is entirely a stub, but it should be in the right place and we can begin to expand the content with further pull requests from here. 