### PR TITLE
Update Compute Node Specifications

### DIFF
--- a/docs/services/cloudservices/ciroh jupyterhub/documentation/conda/index.md
+++ b/docs/services/cloudservices/ciroh jupyterhub/documentation/conda/index.md
@@ -32,7 +32,7 @@ You can activate the environment as usual, using the path to where you created i
 conda activate ~/conda_envs/my_env
 ```
 
-### 4. Autotomatically activate the environment on restart:
+### 4. Automatically activate the environment on restart:
  If you want this environment to be activated every time you log in or the server restarts, you can add the following to your *.bashrc* or *.bash_profile* file:
 
 ```bash

--- a/docs/services/on-prem/Pantarhei/sysinfo.md
+++ b/docs/services/on-prem/Pantarhei/sysinfo.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "System Architecture"
 description: "System Architecture of Pantarhei"
+hide_table_of_contents: false
 tags:
 - HPC
 - On-Premises
@@ -14,12 +15,12 @@ import TabItem from '@theme/TabItem';
 import Heading from '@theme/Heading';
 
 
-# Pantarhei Node Specifications
+# Hardware Specifications
 
 <Tabs>
   <TabItem value="login" label="Login Node" default>
     <div className="container">
-      <table>
+      <table style={{ width: '100%', display: 'inline-table' }}>
         <tr> 
           <th colSpan="6">Pantarhei Login Node</th>
         </tr>
@@ -46,8 +47,8 @@ import Heading from '@theme/Heading';
   <div className="container">
 
     <details style={{backgroundColor: 'transparent', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: 'var(--ifm-global-radius)', padding: 'var(--ifm-spacing-vertical) var(--ifm-spacing-horizontal)'}}>
-      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>Compute Node 001-005</summary>
-      <table  style={{'width':'100%'}}>
+      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>Partition : normal</summary>
+      <table style={{ width: '100%', display: 'inline-table' }}>
 		<tr> 
 			<th colspan="2"> Compute Node Specifications</th>
 		</tr>
@@ -89,7 +90,7 @@ import Heading from '@theme/Heading';
 		</tr>
 		<tr>
 			<td>Cache</td>
-			<td> L1d cache: 1.3 MiB (40 instances)&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<br/>
+			<td> L1d cache: 1.3 MiB (40 instances)<br/>
 				L1i cache: 1.3 MiB (40 instances)<br/>
 				L2 cache: 40 MiB (40 instances)<br/>
 				L3 cache: 55 MiB (2 instances)</td>
@@ -102,8 +103,8 @@ import Heading from '@theme/Heading';
     </details>
 
     <details style={{backgroundColor: 'transparent', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: 'var(--ifm-global-radius)', padding: 'var(--ifm-spacing-vertical) var(--ifm-spacing-horizontal)'}}>
-      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>Compute Node 006-009</summary>
-      <table  style={{'width':'100%'}}>
+      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>Partition : long</summary>
+      <table style={{ width: '100%', display: 'inline-table' }}>
 		<tr> 
 			<th colspan="2"> Compute Node Specifications</th>
 		</tr>
@@ -145,7 +146,7 @@ import Heading from '@theme/Heading';
 		</tr>
 		<tr>
 			<td>Cache</td>
-			<td> L1d cache: 1.5 MiB (32 instances)&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<br/>
+			<td> L1d cache: 1.5 MiB (32 instances)<br/>
 				L1i cache: 1 MiB (32 instances)<br/>
 				L2 cache: 40 MiB (32 instances)<br/>
 				L3 cache: 48 MiB (2 instances)</td>
@@ -158,8 +159,8 @@ import Heading from '@theme/Heading';
     </details>
 
     <details style={{backgroundColor: 'transparent', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: 'var(--ifm-global-radius)', padding: 'var(--ifm-spacing-vertical) var(--ifm-spacing-horizontal)'}}>
-      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>AMD Compute Node</summary>
-      <table  style={{'width':'100%'}}>
+      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>Partition : amd</summary>
+      <table style={{ width: '100%', display: 'inline-table' }}>
 		<tr> 
 			<th colspan="2"> Compute Node Specifications</th>
 		</tr>
@@ -201,7 +202,7 @@ import Heading from '@theme/Heading';
 		</tr>
 		<tr>
 			<td>Cache</td>
-			<td> L1d cache: 4 MiB (128 instances)&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<br/>
+			<td> L1d cache: 4 MiB (128 instances)<br/>
 				L1i cache: 4 MiB (128 instances)<br/>
 				L2 cache: 64 MiB (128 instances)<br/>
 				L3 cache: 512 MiB (32 instances)</td>
@@ -218,8 +219,8 @@ import Heading from '@theme/Heading';
 
   
   <TabItem value="fpga" label="FPGA Nodes">
-    <div className="container">
-      <table style={{width:'100%'}}>
+    <div className="container" >
+      <table style={{ width: '100%', display: 'inline-table' }}>
         <tr> 
           <th colSpan="2">FPGA Node Specifications</th>
         </tr>
@@ -278,7 +279,7 @@ import Heading from '@theme/Heading';
   
   <TabItem value="gpu" label="GPU Nodes">
     <div className="container">
-      <table style={{width:'100%'}}>
+      <table style={{ width: '100%', display: 'inline-table' }}>
         <tr> 
           <th colSpan="2">GPU Node Specifications</th>
         </tr>

--- a/docs/services/on-prem/Pantarhei/sysinfo.md
+++ b/docs/services/on-prem/Pantarhei/sysinfo.md
@@ -8,44 +8,56 @@ tags:
 - System Architecture
 - Pantarhei
 ---
-### Login Node
-<div class="container">
-	<table>
-		<tr> 
-			<th colspan="6"> Pantarhei Login Node</th>
-		</tr>
-		<tr>
-			<td>Number of nodes</td>
-			<td>Processors per node</td>
-			<td>Cores per node</td>
-			<td>Sockets per node</td>
-			<td>Memory per node</td>
-			<td>Local storage per node</td>
-		</tr>
-		<tr>
-			<td>1</td>
-			<td>2x Intel(R) Xeon(R) Silver 4110 CPU @ 2.10GHz</td>
-			<td>16</td>
-			<td>2</td>
-			<td>96 Gb</td>
-			<td>76 TB</td>
-		</tr>
-	</table>
-</div>
 
-### Compute Nodes
-<div class="container">
-	<table  style={{'width':'100%'}}>
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Heading from '@theme/Heading';
+
+
+# Pantarhei Node Specifications
+
+<Tabs>
+  <TabItem value="login" label="Login Node" default>
+    <div className="container">
+      <table>
+        <tr> 
+          <th colSpan="6">Pantarhei Login Node</th>
+        </tr>
+        <tr>
+          <td>Number of nodes</td>
+          <td>Processors per node</td>
+          <td>Cores per node</td>
+          <td>Sockets per node</td>
+          <td>Memory per node</td>
+          <td>Local storage per node</td>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td>2x Intel(R) Xeon(R) Silver 4110 CPU @ 2.10GHz</td>
+          <td>16</td>
+          <td>2</td>
+          <td>96 Gb</td>
+          <td>76 TB</td>
+        </tr>
+      </table>
+    </div>
+  </TabItem>
+  <TabItem value="compute" label="Compute Nodes">
+  <div className="container">
+
+    <details style={{backgroundColor: 'transparent', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: 'var(--ifm-global-radius)', padding: 'var(--ifm-spacing-vertical) var(--ifm-spacing-horizontal)'}}>
+      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>Compute Node 001-005</summary>
+      <table  style={{'width':'100%'}}>
 		<tr> 
 			<th colspan="2"> Compute Node Specifications</th>
 		</tr>
 		<tr>
 			<td>Model</td>
-			<td>Intel(R) Xeon(R) Gold 6148</td>
+			<td>Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz</td>
 		</tr>
 		<tr>
 			<td>Number of nodes</td>
-			<td>6</td>
+			<td>5</td>
 		</tr>
 		<tr>
 			<td>Sockets per node</td>
@@ -82,136 +94,258 @@ tags:
 				L2 cache: 40 MiB (40 instances)<br/>
 				L3 cache: 55 MiB (2 instances)</td>
 		</tr>
-		<tr>
+		<!-- <tr>
 			<td>Local storage per node</td>
 			<td>4 TB</td>
-		</tr>
+		</tr> -->
 	</table>
-</div>
+    </details>
 
-### FPGA Nodes
-<div class="container">
-	<table  style={{'width':'100%'}}>
+    <details style={{backgroundColor: 'transparent', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: 'var(--ifm-global-radius)', padding: 'var(--ifm-spacing-vertical) var(--ifm-spacing-horizontal)'}}>
+      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>Compute Node 006-009</summary>
+      <table  style={{'width':'100%'}}>
 		<tr> 
 			<th colspan="2"> Compute Node Specifications</th>
 		</tr>
 		<tr>
 			<td>Model</td>
-			<td>Intel(R) Xeon(R) Gold 6148</td>
+			<td>Intel(R) Xeon(R) Gold 6326 CPU @ 2.90 GHz</td>
 		</tr>
 		<tr>
 			<td>Number of nodes</td>
-			<td>1</td>
-		</tr>
-		<tr>
-			<td>Sockets per node</td>
-			<td>2</td>
-		</tr>
-		<tr>
-			<td>Cores per socket</td>
-			<td>20</td>
-		</tr>
-		<tr>
-			<td>Cores per node</td>
-			<td>40</td>
-		</tr>
-		<tr>
-			<td>Hardware threads per core</td>
-			<td>1</td>
-		</tr>
-		<tr>
-			<td>Hardware threads per node</td>
-			<td>40</td>
-		</tr>
-		<tr>
-			<td>Clock rate</td>
-			<td>2.40GHz (3.70GHz max boost)</td>
-		</tr>
-		<tr>
-			<td>RAM</td>
-			<td>384 GB DDR4-2666</td>
-		</tr>
-		<tr>
-			<td>Cache</td>
-			<td> L1d cache: 1.3 MiB (40 instances)&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<br/>
-				L1i cache: 1.3 MiB (40 instances)<br/>
-				L2 cache: 40 MiB (40 instances)<br/>
-				L3 cache: 55 MiB (2 instances)</td>
-		</tr>
-		<tr>
-			<td>Local storage per node</td>
-			<td>2 TB</td>
-		</tr>
-	</table>
-</div>
-
-### GPU Nodes
-<div class="container">
-	<table  style={{'width':'100%'}}>
-		<tr> 
-			<th colspan="2"> Compute Node Specifications</th>
-		</tr>
-		<tr>
-			<td>Model</td>
-			<td>Intel(R) Xeon(R) Gold 6148</td>
-		</tr>
-		<tr>
-			<td>Number of nodes</td>
-			<td>1</td>
-		</tr>
-		<tr>
-			<td>Sockets per node</td>
-			<td>2</td>
-		</tr>
-		<tr>
-			<td>Cores per socket</td>
-			<td>20</td>
-		</tr>
-		<tr>
-			<td>Cores per node</td>
-			<td>40</td>
-		</tr>
-		<tr>
-			<td>Hardware threads per core</td>
-			<td>1</td>
-		</tr>
-		<tr>
-			<td>Hardware threads per node</td>
-			<td>40</td>
-		</tr>
-		<tr>
-			<td>Clock rate</td>
-			<td>2.40GHz (3.70GHz max boost)</td>
-		</tr>
-		<tr>
-			<td>RAM</td>
-			<td>384 GB DDR4-2666</td>
-		</tr>
-		<tr>
-			<td>Cache</td>
-			<td> L1d cache: 1.3 MiB (40 instances)&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<br/>
-				L1i cache: 1.3 MiB (40 instances)<br/>
-				L2 cache: 40 MiB (40 instances)<br/>
-				L3 cache: 55 MiB (2 instances)</td>
-		</tr>
-		<tr>
-			<td>Local storage per node</td>
-			<td>3 TB</td>
-		</tr>
-		<tr>
-			<td>Number GPUs per node</td>
 			<td>4</td>
 		</tr>
 		<tr>
-			<td>GPU model</td>
-			<td>NVIDIA Tesla V100 SXM2</td>
+			<td>Sockets per node</td>
+			<td>2</td>
 		</tr>
 		<tr>
-			<td>Memory per GPU</td>
-			<td>16 GB</td>
+			<td>Cores per socket</td>
+			<td>16</td>
 		</tr>
+		<tr>
+			<td>Cores per node</td>
+			<td>64</td>
+		</tr>
+		<tr>
+			<td>Hardware threads per core</td>
+			<td>2</td>
+		</tr>
+		<tr>
+			<td>Hardware threads per node</td>
+			<td>64</td>
+		</tr>
+		<tr>
+			<td>Clock rate</td>
+			<td>2.90GHz (3.50GHz max boost)</td>
+		</tr>
+		<tr>
+			<td>RAM</td>
+			<td>256 GB DDR4-2666</td>
+		</tr>
+		<tr>
+			<td>Cache</td>
+			<td> L1d cache: 1.5 MiB (32 instances)&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<br/>
+				L1i cache: 1 MiB (32 instances)<br/>
+				L2 cache: 40 MiB (32 instances)<br/>
+				L3 cache: 48 MiB (2 instances)</td>
+		</tr>
+		<!-- <tr>
+			<td>Local storage per node</td>
+			<td>4 TB</td>
+		</tr> -->
 	</table>
-</div>
+    </details>
 
+    <details style={{backgroundColor: 'transparent', border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: 'var(--ifm-global-radius)', padding: 'var(--ifm-spacing-vertical) var(--ifm-spacing-horizontal)'}}>
+      <summary style={{backgroundColor: 'transparent', color: 'var(--ifm-color-primary)', fontWeight: 'var(--ifm-font-weight-bold)'}}>AMD Compute Node</summary>
+      <table  style={{'width':'100%'}}>
+		<tr> 
+			<th colspan="2"> Compute Node Specifications</th>
+		</tr>
+		<tr>
+			<td>Model</td>
+			<td>AMD EPYC 7702 64-Core Processor</td>
+		</tr>
+		<tr>
+			<td>Number of nodes</td>
+			<td>1</td>
+		</tr>
+		<tr>
+			<td>Sockets per node</td>
+			<td>2</td>
+		</tr>
+		<tr>
+			<td>Cores per socket</td>
+			<td>64</td>
+		</tr>
+		<tr>
+			<td>Cores per node</td>
+			<td>256</td>
+		</tr>
+		<tr>
+			<td>Hardware threads per core</td>
+			<td>2</td>
+		</tr>
+		<tr>
+			<td>Hardware threads per node</td>
+			<td>256</td>
+		</tr>
+		<tr>
+			<td>Clock rate</td>
+			<td>2.00GHz (3.40GHz max boost)</td>
+		</tr>
+		<tr>
+			<td>RAM</td>
+			<td>512 GB DDR4-2666</td>
+		</tr>
+		<tr>
+			<td>Cache</td>
+			<td> L1d cache: 4 MiB (128 instances)&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;<br/>
+				L1i cache: 4 MiB (128 instances)<br/>
+				L2 cache: 64 MiB (128 instances)<br/>
+				L3 cache: 512 MiB (32 instances)</td>
+		</tr>
+		<!-- <tr>
+			<td>Local storage per node</td>
+			<td>4 TB</td>
+		</tr> -->
+	</table>
+    </details>
+
+  </div>
+</TabItem>
+
+  
+  <TabItem value="fpga" label="FPGA Nodes">
+    <div className="container">
+      <table style={{width:'100%'}}>
+        <tr> 
+          <th colSpan="2">FPGA Node Specifications</th>
+        </tr>
+        <tr>
+          <td>Model</td>
+          <td>Intel(R) Xeon(R) Gold 6148</td>
+        </tr>
+        <tr>
+          <td>Number of nodes</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <td>Sockets per node</td>
+          <td>2</td>
+        </tr>
+        <tr>
+          <td>Cores per socket</td>
+          <td>20</td>
+        </tr>
+        <tr>
+          <td>Cores per node</td>
+          <td>40</td>
+        </tr>
+        <tr>
+          <td>Hardware threads per core</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <td>Hardware threads per node</td>
+          <td>40</td>
+        </tr>
+        <tr>
+          <td>Clock rate</td>
+          <td>2.40GHz (3.70GHz max boost)</td>
+        </tr>
+        <tr>
+          <td>RAM</td>
+          <td>384 GB DDR4-2666</td>
+        </tr>
+        <tr>
+          <td>Cache</td>
+          <td>
+            L1d cache: 1.3 MiB (40 instances)<br/>
+            L1i cache: 1.3 MiB (40 instances)<br/>
+            L2 cache: 40 MiB (40 instances)<br/>
+            L3 cache: 55 MiB (2 instances)
+          </td>
+        </tr>
+        <tr>
+          <td>Local storage per node</td>
+          <td>2 TB</td>
+        </tr>
+      </table>
+    </div>
+  </TabItem>
+  
+  <TabItem value="gpu" label="GPU Nodes">
+    <div className="container">
+      <table style={{width:'100%'}}>
+        <tr> 
+          <th colSpan="2">GPU Node Specifications</th>
+        </tr>
+        <tr>
+          <td>Model</td>
+          <td>Intel(R) Xeon(R) Gold 6148</td>
+        </tr>
+        <tr>
+          <td>Number of nodes</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <td>Sockets per node</td>
+          <td>2</td>
+        </tr>
+        <tr>
+          <td>Cores per socket</td>
+          <td>20</td>
+        </tr>
+        <tr>
+          <td>Cores per node</td>
+          <td>40</td>
+        </tr>
+        <tr>
+          <td>Hardware threads per core</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <td>Hardware threads per node</td>
+          <td>40</td>
+        </tr>
+        <tr>
+          <td>Clock rate</td>
+          <td>2.40GHz (3.70GHz max boost)</td>
+        </tr>
+        <tr>
+          <td>RAM</td>
+          <td>384 GB DDR4-2666</td>
+        </tr>
+        <tr>
+          <td>Cache</td>
+          <td>
+            L1d cache: 1.3 MiB (40 instances)<br/>
+            L1i cache: 1.3 MiB (40 instances)<br/>
+            L2 cache: 40 MiB (40 instances)<br/>
+            L3 cache: 55 MiB (2 instances)
+          </td>
+        </tr>
+        <tr>
+          <td>Local storage per node</td>
+          <td>3 TB</td>
+        </tr>
+        <tr>
+          <td>Number GPUs per node</td>
+          <td>4</td>
+        </tr>
+        <tr>
+          <td>GPU model</td>
+          <td>NVIDIA Tesla V100 SXM2</td>
+        </tr>
+        <tr>
+          <td>Memory per GPU</td>
+          <td>16 GB</td>
+        </tr>
+      </table>
+    </div>
+  </TabItem>
+</Tabs>
 ### Network
 All nodes are interconnected by a Mellanox InfiniBand switch with FDR 56 Gb/s networks.

--- a/docs/services/on-prem/Pantarhei/sysinfo.md
+++ b/docs/services/on-prem/Pantarhei/sysinfo.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 title: "System Architecture"
 description: "System Architecture of Pantarhei"
-hide_table_of_contents: false
+hide_table_of_contents: true
 tags:
 - HPC
 - On-Premises


### PR DESCRIPTION
1.  Updated Compute Node Specifications to reflect three different types: Compute 001-005, Compute 006-009, and AMD Compute.
2.  Added collapsible sections under Compute Node to make it easier to navigate.

![image](https://github.com/user-attachments/assets/c0c1b77f-e1f4-42b9-ac9c-1e90f2297f21)
![image](https://github.com/user-attachments/assets/fdd78bcd-1eaa-45e1-b870-b7b4fb8a0bde)
![image](https://github.com/user-attachments/assets/fd078e32-a9ca-404b-b3ad-4f7bc374d77a)
![image](https://github.com/user-attachments/assets/c114d98a-a704-460d-bf5d-4e99602544ff)


