### PR TITLE
Add Accessing JetStream2 Page and Update Infrastructure Form Links

### DIFF
--- a/docs/services/external-resources/nsf-access/access.md
+++ b/docs/services/external-resources/nsf-access/access.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 2
+title: "Accessing JetStream2"
+description: "Access JetStream2"
+tags:
+  - NSF
+  - JetStream2
+  - Account
+  - Access
+---
+
+JetStream2 is accessible to the CIROH members and partners of the Cooperative Institute for Research to Operations in Hydrology (CIROH).
+
+### How to get access to JetStream2?
+Step 1: Submit the Infrastructure Request Form below to get access to JetStream2:
+
+We encourage PI of the project to start here: (select Infrastructure Request Form and fill out details)
+
+<a class="button button--active button--primary" href="https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?assignees=&labels=on-prem&projects=&template=onprem-request.md&title="> Infrastructure Request Form</a>
+
+---
+
+Step 2: Submit the JetStream2 Access Request form for individual user accounts on JetStream2:
+
+<a class="button button--active button--primary" href="https://forms.office.com/r/ERyKyHbdaC"> JetStream2 Access Request Form</a>
+
+
+---
+ **Note**: If you are unable to access the JetStream2 forms, please contact the CIROH team at ciroh-it-admin@ua.edu for assistance.

--- a/docs/services/external-resources/nsf-access/index.md
+++ b/docs/services/external-resources/nsf-access/index.md
@@ -15,9 +15,9 @@ Here are some useful links to get started:
 - [Supported Resources](https://allocations.access-ci.org/resources)
 
 
-## Recommended Resources for CIROH projects:
+# Recommended Resources for CIROH projects:
 
- ### JetStream2
+ ## JetStream2
 
 Jetstream2 is a powerful hybrid-cloud platform designed for researchers and educators. It offers a range of flexible, on-demand, and programmable infrastructure tools, from interactive virtual machines (VMs) to advanced infrastructure and orchestration services. The primary resource consists of AMD Milan 7713 CPUs with 128 cores per node and 512 GB RAM per node, all connected by a high-speed 100 gbps wthernet.
 
@@ -36,16 +36,16 @@ Jetstream2 is ideal for researchers with diverse needs:
 
 For information about available instance sizes, visit the [JetStream2 VM Sizes](https://docs.jetstream-cloud.org/general/vmsizes/) page.
 
-
-<a class="button button--active button--primary" style={{'margin-right':'1.3rem','margin-bottom':'1.3rem'}}  href="https://jetstream-cloud.org/get-started/index.html ">Get Started with JetStream2</a>
-<a class="button button--active button--primary" style={{'margin-right':'1.3rem','margin-bottom':'1.3rem'}}  href="https://docs.jetstream-cloud.org/getting-started/login/">Logging in to JetStream2</a>
-
+### To get started with JetStream2:
+- **Create an Account:** Follow the detailed instructions on the [Get Started with JetStream2 page](https://jetstream-cloud.org/get-started/index.html) to set up your account and request access.<br />
+- **Request Access**: After completing the setup, proceed by following the steps outlined on the [Accessing JetStream2 page.](./access) <br />
+- **Log In and Start:** Once you’ve gained access, visit the [logging in to JetStream2 page.](https://docs.jetstream-cloud.org/getting-started/login/) to begin using JetStream2.
 
 :::info
 For a more detailed information on JetStream2, visit the official NSF ACCESS Jetstream2 website <a href="https://docs.jetstream-cloud.org/">here.</a>
 :::
 
-### Anvil 
+## Anvil 
 Anvil is a powerful supercomputer, offering computing power for demanding research problems. Purdue's Anvil cluster consists of 1,000 nodes with two 64-core AMD EPYC "Milan" processors each and delivers over one billion CPU core hours each year. With a peak performance of 5.1 petaflops and a speed of 100 Gbps interconnect, Anvil ensures rapid data transfer and processing for efficient research workflows. Standard Anvil nodes have 256GB of DDR4-3200 memory each, ideal for most research tasks.
 
 
@@ -53,10 +53,11 @@ Anvil is a powerful supercomputer, offering computing power for demanding resear
 				<img src="https://www.rcac.purdue.edu/files/anvil/Anvil_cummulative_8-2024_stats_only%20%281%29.png" alt="jetstream2 logo"/>
 				<i>Image Source: <a href="https://www.rcac.purdue.edu/anvil">https://www.rcac.purdue.edu/anvil</a> </i>
 </div>
+
 ### Use cases:
-**General-Purpose CPU Power**: Anvil's powerful CPUs (with 128 cores per node) are ideal for computationally intensive tasks suitable for modeling and simulation across scientific and engineering fields.
-**Memory-Intensive Workloads**: The dedicated large memory nodes (with 1TB of DDR4-3200 memory per node) works bestfor research that demands significant memory resources.
-**Composable Subsystem**: It is a private cloud built on Kubernetes and consists of bothe CPU and GPU nodes and S3 data storage. It is suitable for applications such as model inference service (via NVIDIA Triton), Specialized LLMs, dataset hosting, science gateways and web application hosting, and classroom and training applications via interactive access interfaces.
+- **General-Purpose CPU Power**: Anvil's powerful CPUs (with 128 cores per node) are ideal for computationally intensive tasks suitable for modeling and simulation across scientific and engineering fields.
+- **Memory-Intensive Workloads**: The dedicated large memory nodes (with 1TB of DDR4-3200 memory per node) works bestfor research that demands significant memory resources.
+- **Composable Subsystem**: It is a private cloud built on Kubernetes and consists of bothe CPU and GPU nodes and S3 data storage. It is suitable for applications such as model inference service (via NVIDIA Triton), Specialized LLMs, dataset hosting, science gateways and web application hosting, and classroom and training applications via interactive access interfaces.
 
 <a class="button button--active button--primary" style={{'margin-right':'1.3rem','margin-bottom':'1.3rem'}}  href="https://www.rcac.purdue.edu/anvil#docs">Anvil Documentation</a>
 

--- a/docs/services/on-prem/Pantarhei/obtain.md
+++ b/docs/services/on-prem/Pantarhei/obtain.md
@@ -17,7 +17,7 @@ Pantarhei cluster is accessible to the CIROH members and partners of the Coopera
 
 We encourage PI of the project to start here: (select On-Premises Infrastructure Request Form and fill out details)
 
-<a class="button button--active button--primary" href="https://docs.ciroh.org/docs/services/access/#on-premises"> Infrastructure Request Form</a>
+<a class="button button--active button--primary" href="https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?assignees=&labels=on-prem&projects=&template=onprem-request.md&title="> Infrastructure Request Form</a>
 
 ---
 

--- a/docs/services/on-prem/Wukong/obtain.md
+++ b/docs/services/on-prem/Wukong/obtain.md
@@ -15,7 +15,7 @@ Wukong cluster is accessible to the research community of the Cooperative Instit
 
 To obtain an account, users will need to follow these step:
 
-1. Submit [On-premises Infrastructure Request Form](/docs/services/access#on-premises) and describe full project information and resouce requirements.
+1. Submit [On-premises Infrastructure Request Form](https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/new?assignees=&labels=on-prem&projects=&template=onprem-request.md&title=) and describe full project information and resouce requirements.
 
 	::::::warning
 	This GitHub issue must be submitted by Principal Investigator (PI) of the project. 


### PR DESCRIPTION
1. Created a new Accessing JetStream2 page where the PI and researcher each need to fill out separate forms to request access.
2. Updated the infrastructure form link in both obtain.md files of Pantarhei and Wukong.

![Screenshot 2024-10-01 095912](https://github.com/user-attachments/assets/1c31ac0d-a3d5-4774-a5a1-89971f7d070d)
![image](https://github.com/user-attachments/assets/1941da92-2112-467a-98b0-0f9df31cf087)
