### PR TITLE
Addition of Flood Inundation Mapping framework github into CIROH Docuhub as products

### DIFF
--- a/docs/products/Flood Inundation Mapping/FIMPEF/index.md
+++ b/docs/products/Flood Inundation Mapping/FIMPEF/index.md
@@ -3,12 +3,12 @@ sidebar_position: 1
 title: "FIMPEF"
 description: "FIMPEF"
 tags:
-    - FIM evaluation,
-    - Large scale evaluation, 
-    - cloud computing,
+    - FIM evaluation
+    - Large scale evaluation 
+    - cloud computing
     - convex hull
     - smallest extent
-    - CONUS, 
+    - CONUS
     - fluvial flood
 ---
 

--- a/docs/products/Flood Inundation Mapping/FIMPEF/index.md
+++ b/docs/products/Flood Inundation Mapping/FIMPEF/index.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+title: "FIMPEF"
+description: "FIMPEF"
+tags:
+    - FIM evaluation,
+    - Large scale evaluation, 
+    - cloud computing,
+    - convex hull
+    - smallest extent
+    - CONUS, 
+    - fluvial flood
+---
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+ 
+<GitHubReadme username="sdmlua" repo="fimpef" />


### PR DESCRIPTION
Here I added a Flood Inundation Mapping Predictions Evaluation Framework (FIMPEF) github version. This tool is mainly used for the large scale flood evaluation. This work would help others to evaluate their model predicted Flood Maps, that is why we want to share this tool with CIROH community. 

This tool is developed in Surface Dynamics Modeling Lab (SDML),  UA. 
