### PR TITLE
Sanitize commit message in CI pipeline

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -107,7 +107,9 @@ jobs:
     # Trigger CD workflow using repository dispatch          
     - name: Trigger deployment
       uses: peter-evans/repository-dispatch@v2
+      env:
+        
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         event-type: build-completed
-        client-payload: '{"short_hash": "${{ steps.short-sha.outputs.SHORT_SHA }}", "commit_hash": "${{ github.sha }}", "commit_message": "${{ github.event.head_commit.message }}", "branch": "${{ github.ref_name }}", "env": "${{ env.DEPLOY_ENV }}", "version": "${{ env.VERSION }}"}'
+        client-payload: '{"short_hash": "${{ steps.short-sha.outputs.SHORT_SHA }}", "commit_hash": "${{ github.sha }}", "commit_message": ${{ toJSON(github.event.head_commit.message) }}, "branch": "${{ github.ref_name }}", "env": "${{ env.DEPLOY_ENV }}", "version": "${{ env.VERSION }}"}'


### PR DESCRIPTION
Should prevent issues such as the one seen in https://github.com/CIROH-UA/ciroh-ua_website/actions/runs/15171933889/job/42663861100, where the use of quotation marks in a pull request breaks attempts at merging.