### PR TITLE
Remove unknown placeholder formatting

### DIFF
--- a/docs/products/Mobile Apps/RIVR/index.mdx
+++ b/docs/products/Mobile Apps/RIVR/index.mdx
@@ -68,13 +68,13 @@ Manage your list of rivers within the RIVR App:
 
 To access detailed forecasts for a river:
 
-1.  Select a river from your "My Rivers" list \, or choose it from the map interface \.
-2.  You'll be taken to the river's detail page, where you can view current flow, flow status, and forecast information \, \, \, \, \, \, \, \, \, \, \, \, \.
-3.  The river's name and location (e.g., Louisville, Kentucky) will be displayed \.
-4.  Current flow is shown in ft³/s \, \, \, \, \, \, \, \, \, \, \, \.
-5.  Flow status (e.g., "Low") indicates the current condition \, \, \, \, \, \, \.
-6.  Return period information is available showing 2-year, 5-year, 10-year, 25-year, 50-year, and 100-year flow benchmarks \, \, \, \, \, \.
-7.  Hydrographs (graphs of flow over time) are provided for different ranges \, \, \, \, \, \, \, \.
+1.  Select a river from your "My Rivers" list, or choose it from the map interface.
+2.  You'll be taken to the river's detail page, where you can view current flow, flow status, and forecast information.
+3.  The river's name and location (e.g., Louisville, Kentucky) will be displayed.
+4.  Current flow is shown in ft³/s.
+5.  Flow status (e.g., "Low") indicates the current condition.
+6.  Return period information is available showing 2-year, 5-year, 10-year, 25-year, 50-year, and 100-year flow benchmarks.
+7.  Hydrographs (graphs of flow over time) are provided for different ranges.
 
 <img src={require('@site/static/img/products/ciroh-rivr/15.png').default} style={{maxHeight: "30rem"}} />
 <img src={require('@site/static/img/products/ciroh-rivr/16.png').default} style={{maxHeight: "30rem"}} />
@@ -84,9 +84,9 @@ To access detailed forecasts for a river:
 
 Hourly forecasts provide detailed short-range flow predictions:
 
-1.  Select the "Hourly" tab or option on the river's detail page \, \, \, \, \, \, \, \[26\].
+1.  Select the "Hourly" tab or option on the river's detail page.
 2.  See the hourly flow forecast in ft³/s for the next few hours.
-3.  View the hourly hydrograph, which shows predicted flow over time. The graph may be available in different view options such as "Wave View" \, \, \.
+3.  View the hourly hydrograph, which shows predicted flow over time. The graph may be available in different view options such as "Wave View".
 
 <img src={require('@site/static/img/products/ciroh-rivr/18.png').default} style={{maxHeight: "30rem"}} />
 <img src={require('@site/static/img/products/ciroh-rivr/19.png').default} style={{maxHeight: "30rem"}} />
@@ -95,9 +95,9 @@ Hourly forecasts provide detailed short-range flow predictions:
 
 Daily forecasts give medium-range flow predictions:
 
-1.  Select the "Daily" tab or option on the river's detail page \, \, \, \, \, \, \, \, \[23\], \[24\], \[26\].
+1.  Select the "Daily" tab or option on the river's detail page.
 2.  View the daily flow forecast for the next several days.
-3.  See the daily hydrograph showing predicted flow trends over the next few days \, \.
+3.  See the daily hydrograph showing predicted flow trends over the next few days.
 
 <img src={require('@site/static/img/products/ciroh-rivr/20.png').default} style={{maxHeight: "30rem"}} />
 <img src={require('@site/static/img/products/ciroh-rivr/21.png').default} style={{maxHeight: "30rem"}} />
@@ -108,9 +108,9 @@ Daily forecasts give medium-range flow predictions:
 
 Long-range (Monthly) forecasts provide an overview of flow trends:
 
-1.  Select the "Monthly" tab or option on the river's detail page \, \, \, \, \, \, \, \, \, \[26\], \[27\].
+1.  Select the "Monthly" tab or option on the river's detail page.
 2.  See the monthly flow forecast for the upcoming month.
-3.  View the monthly hydrograph depicting predicted flow trends over the month \, \[27\].
+3.  View the monthly hydrograph depicting predicted flow trends over the month.
 
 <img src={require('@site/static/img/products/ciroh-rivr/25.png').default} style={{maxHeight: "30rem"}} />
 <img src={require('@site/static/img/products/ciroh-rivr/26.png').default} style={{maxHeight: "30rem"}} />
@@ -118,7 +118,7 @@ Long-range (Monthly) forecasts provide an overview of flow trends:
 
 ## User Account Management
 
-1. In the settings you can see Units & Theme, Notifications & Alerts, Data Management, Help & Information, and Feedback & Support as shown in \.
+In the settings you can see Units & Theme, Notifications & Alerts, Data Management, Help & Information, and Feedback & Support.
 
 ## About the Developers
 


### PR DESCRIPTION
Not sure if/when this page's revisions are planned, but given that most of these placeholder bits seems like they were lost in translation at some point anyway, there seems to be no harm in removing them.