### PR TITLE
Replace deprecated function in CI pipeline

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -34,7 +34,7 @@ jobs:
         
     - name: Generate version
       id: version
-      run: echo "::set-output name=VERSION::$(date +'%Y%m%d-%H%M%S')"
+      run: echo "VERSION=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/