### PR TITLE
fix: Correct broken anchor links in service documentation

### DIFF
--- a/docs/products/Community Hydrologic Modeling Framework/nextgeninaboxDocker/workflow-cloud.mdx
+++ b/docs/products/Community Hydrologic Modeling Framework/nextgeninaboxDocker/workflow-cloud.mdx
@@ -40,7 +40,7 @@ The first step involves preparing the necessary input data for the NGIAB model:
 
 1. **Access the CIROH JupyterHub**
    - Navigate to [CIROH JupyterHub](https://ciroh.awi.2i2c.cloud/)
-   - If you need access, [request it here](/docs/services/access#accessing-ciroh-jupyterhub)
+   - If you need access, [request it here](/docs/services/access#accessing-ciroh-2i2c-jupyterhub)
 
 2. **Select the Appropriate Environment**
    - When starting your server, choose "NGIAB Data Preprocess" from the dropdown menu

--- a/docs/services/cloudservices/HydroShare/index.mdx
+++ b/docs/services/cloudservices/HydroShare/index.mdx
@@ -18,7 +18,7 @@ HydroShare is a repository, website, and hydrologic information system for shari
 
 Users now have the capability to directly launch and execute computational notebooks from HydroShare resources into the CIROH Jupyterhub environments. Here's how to get started:
 
-1. First, confirm that you have access to the CIROH Jupyterhub. If not, follow [these steps](/docs/services/access#accessing-ciroh-jupyterhub)
+1. First, confirm that you have access to the CIROH Jupyterhub. If not, follow [these steps](/docs/services/access#accessing-ciroh-2i2c-jupyterhub)
 
 2. CIROH Jupyterhub is an approved app, and appears on https://www.hydroshare.org/apps/. Navigate to this page to access it directly, or select it from the "Open with" list on any resource that you have access to containing a Jupyter notebook. 
 

--- a/docs/services/cloudservices/ciroh jupyterhub/index.mdx
+++ b/docs/services/cloudservices/ciroh jupyterhub/index.mdx
@@ -39,7 +39,7 @@ Watch this video to find out how to access CIROH Jupyterhub and how to launch an
 
 CIROH JupyterHub provides both CPU and GPU capabilities. To get started, please head to the Infrastructure Access page.
 
-<Link class="button button--active button--primary" to="/docs/services/access#accessing-ciroh-jupyterhub">Infrastructure Access</Link>
+<Link class="button button--active button--primary" to="/docs/services/access#accessing-ciroh-2i2c-jupyterhub">Infrastructure Access</Link>
 
 -----
 ## Requesting Software Installation on CIROH JupyterHub


### PR DESCRIPTION
This PR fixes three broken internal anchor links that were causing warnings during the `npm run build` process. The links have been updated to point to the correct section ID on the services access page.

Three internal links were pointing to a non-existent section ID (`#accessing-ciroh-jupyterhub`). These have been updated to point to the correct ID (`#accessing-ciroh-2i2c-jupyterhub`) in the following files:

* `docs/products/Community\ Hydrologic\ Modeling\ Framework/nextgeninaboxDocker/workflow-cloud.mdx`
* `docs/services/cloudservices/HydroShare/index.mdx`
* `docs/services/cloudservices/ciroh\ jupyterhub/index.mdx`