### PR TITLE
Products tab overhaul: README rewritten; NextGen Datastream subpages

### DIFF
--- a/docs/products/ngiab/components/ngiab-calibration/index.mdx
+++ b/docs/products/ngiab/components/ngiab-calibration/index.mdx
@@ -7,4 +7,4 @@ tags: [Products, CIROH, NGIAB, National Water Model, Calibration]
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
 
-<GitHubReadme username="CIROH-UA" repo="ngiab_cal" />
+<GitHubReadme username="CIROH-UA" repo="ngiab_cal" trimTitle="true" />

--- a/docs/products/ngiab/components/ngiab-preprocessor/index.mdx
+++ b/docs/products/ngiab/components/ngiab-preprocessor/index.mdx
@@ -7,4 +7,4 @@ tags: [Products, NGIAB, CIROH, National Water Model]
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
  
-<GitHubReadme username="CIROH-UA" repo="NGIAB_data_preprocess" />
+<GitHubReadme username="CIROH-UA" repo="NGIAB_data_preprocess" trimTitle="true" />

--- a/docs/products/ngiab/components/ngiab-teehr/index.mdx
+++ b/docs/products/ngiab/components/ngiab-teehr/index.mdx
@@ -7,4 +7,4 @@ tags: [Products, NGIAB, CIROH, Cloud Services, Docker, National Water Model, TEE
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
  
-<GitHubReadme username="CIROH-UA" repo="ngiab-teehr" />
+<GitHubReadme username="CIROH-UA" repo="ngiab-teehr" trimTitle="true" />

--- a/docs/products/ngiab/components/ngiab-visualizer/index.mdx
+++ b/docs/products/ngiab/components/ngiab-visualizer/index.mdx
@@ -7,4 +7,4 @@ tags: [Products, NGIAB, CIROH, Cloud Services, Docker, National Water Model, Edu
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
  
-<GitHubReadme username="CIROH-UA" repo="ngiab-client" />
+<GitHubReadme username="CIROH-UA" repo="ngiab-client" trimTitle="true" />

--- a/docs/products/ngiab/extensions/community-hydrofabric/index.mdx
+++ b/docs/products/ngiab/extensions/community-hydrofabric/index.mdx
@@ -10,4 +10,4 @@ tags:
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
  
-<GitHubReadme username="CIROH-UA" repo="community_hf_patcher" />
+<GitHubReadme username="CIROH-UA" repo="community_hf_patcher" trimTitle="true" />

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/breakdown.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/breakdown.mdx
@@ -10,7 +10,7 @@ tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
 :::warning
 This document is primarily intended to explain what steps DataStreamCLI performs internally.  
 Performing these steps manually is discouraged, as a typical call to `scripts/datastream` will handle all of this for you.  
-If you're looking for a guide for how to run the script, run `scripts/datastream-guide` after [installation](products/ngiab/extensions/nextgen-datastream/cli/install) for an interactive tutorial.
+If you're looking for a guide for how to run the script, run `scripts/datastream-guide` after [installation](/docs/products/ngiab/extensions/nextgen-datastream/cli/install) for an interactive tutorial.
 :::
 
 import GitHubReadme from '@site/src/components/GitHubReadme';

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/breakdown.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/breakdown.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 6
+title: "Internal Breakdown"
+description: "An end-to-end tour of the internal workings of DataStreamCLI."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
+---
+
+# DataStreamCLI Breakdown
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="BREAKDOWN.md" trimTitle="false"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/breakdown.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/breakdown.mdx
@@ -7,6 +7,12 @@ tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
 
 # DataStreamCLI Breakdown
 
+:::warning
+This document is primarily intended to explain what steps DataStreamCLI performs internally.  
+Performing these steps manually is discouraged, as a typical call to `scripts/datastream` will handle all of this for you.  
+If you're looking for a guide for how to run the script, run `scripts/datastream-guide` after [installation](products/ngiab/extensions/nextgen-datastream/cli/install) for an interactive tutorial.
+:::
+
 import GitHubReadme from '@site/src/components/GitHubReadme';
 
 <GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="BREAKDOWN.md" trimTitle="false"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/directories.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/directories.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 4
+title: "Directory Structure"
+description: "The directory structure in DataStreamCLI."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
+---
+
+# DataStreamCLI Directory Structure
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="STANDARD_DIRECTORIES.md" trimTitle="false"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/index.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/index.mdx
@@ -1,0 +1,10 @@
+---
+sidebar_position: 2
+title: 'DatastreamCLI'
+description: "The software backend of the Research Datastream."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
+---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/install.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/install.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+title: "Installation"
+description: "Learn what you'll need to install DataStreamCLI."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
+---
+
+# Installing DataStreamCLI
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="" readmeFileName="INSTALL.md" trimTitle="false"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/models.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/models.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 3
+title: "Available Models"
+description: "The available models in DataStreamCLI."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
+---
+
+<!-- TODO: The information present here would really benefit from being translated to the general tab. -->
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="NGEN_MODELS.md" trimTitle="false"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/options.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/options.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 5
+title: "CLI Options"
+description: "The available options in DataStreamCLI."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
+---
+
+# DataStreamCLI Options
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="DATASTREAM_OPTIONS.md" trimTitle="false"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/usage.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/usage.mdx
@@ -9,4 +9,4 @@ tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
 
-<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="USAGE.md" trimTitle="false"/>
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="USAGE.md" trimTitle="true"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/cli/usage.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/cli/usage.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 2
+title: "Usage Guide"
+description: "How to get the most out of DataStreamCLI."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
+---
+
+# DataStreamCLI Usage Guide
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="docs" readmeFileName="USAGE.md" trimTitle="false"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/components/forcingprocessor/forcing_sources.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/components/forcingprocessor/forcing_sources.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+title: "Forcing Sources"
+description: "An overview of Forcing Processor sources."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, AWS, National Water Model]
+---
+
+# Forcing Processor Sources
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="forcingprocessor" readmeFileName="FORCING_SOURCES.md"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/components/forcingprocessor/index.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/components/forcingprocessor/index.mdx
@@ -1,7 +1,7 @@
 ---
-sidebar_position: 7
+sidebar_position: 3
 title: "Forcing Processor"
-description: "NextGen Forcing Processor"
+description: "Converts National Water Model (NWM) forcing data into Next Generation National Water Model (NextGen) forcing data."
 tags: [Products, CIROH, NGIAB, NextGen Datastream, AWS, National Water Model]
 ---
 

--- a/docs/products/ngiab/extensions/nextgen-datastream/components/index.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/components/index.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 5
+title: 'Datastream Components'
+description: "Get the most out of sub-utilities in the NGIAB ecosystem."
+tags: [CIROH, NGIAB, Products]
+---
+
+# NextGen Datastream Components
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/products/ngiab/extensions/nextgen-datastream/components/python_tools/index.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/components/python_tools/index.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 2
+title: "Datastream Python Tools"
+description: "Scripts to create ngen bmi module configuration files and validate ngen-run packages."
+tags: [Products, CIROH, NGIAB, NextGen Datastream, AWS, National Water Model]
+---
+
+# NextGen Datastream Python Tools
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="python_tools" readmeFileName="README.md" trimTitle="true"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/forcingprocessor/forcingprocessor.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/forcingprocessor/forcingprocessor.mdx
@@ -9,4 +9,4 @@ tags: [Products, CIROH, NGIAB, NextGen Datastream, AWS, National Water Model]
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
 
-<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="forcingprocessor" readmeFileName = "README.md"/>
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="forcingprocessor" readmeFileName="README.md" trimTitle="true"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/index.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/index.mdx
@@ -11,4 +11,4 @@ The NextGen DataStream forcing files and associated metadata are available throu
 
 import GitHubReadme from '@site/src/components/GitHubReadme';
  
-<GitHubReadme username="CIROH-UA" repo="ngen-datastream" />
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" trimTitle="true" />

--- a/docs/products/ngiab/extensions/nextgen-datastream/research_datastream/index.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/research_datastream/index.mdx
@@ -1,0 +1,15 @@
+---
+sidebar_position: 4
+title: "Research Datastream"
+description: "NextGen Framework Research Datastream"
+tags: [Products, CIROH, NGIAB, NextGen Datastream, AWS, National Water Model]
+---
+
+# NextGen Research Datastream
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="research_datastream" readmeFileName="README.md" trimTitle="true"/>
+
+
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" subfolder="research_datastream" readmeFileName="CONTRIBUTE.md" trimTitle="true"/>

--- a/docs/products/ngiab/extensions/nextgen-datastream/status.mdx
+++ b/docs/products/ngiab/extensions/nextgen-datastream/status.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 999
+title: "Datastream Status"
+description: "NextGen Datastream Status"
+tags: [Products, CIROH, NGIAB, NextGen Datastream, AWS, National Water Model]
+---
+
+# NextGen Datastream Status
+
+import GitHubReadme from '@site/src/components/GitHubReadme';
+ 
+<GitHubReadme username="CIROH-UA" repo="ngen-datastream" readmeFileName="STATUS.md"  />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -195,6 +195,11 @@ const config = {
             to: '/docs/services/cloudservices/google-cloud',
             from: '/docs/products/cloudservices/google cloud',
           },
+          // Contribute: older redirect (formerly used react-router-dom)
+          {
+            to: '/docs/contribute',
+            from: '/contribute',
+          },
         ],
         createRedirects(existingPath) {
           // JupyterHub redirects


### PR DESCRIPTION
- README component:
  - General refactoring for code clarity, flow, and decoupling.
  - Now correctly links to the target markdown file, rather than always pointing to the root README.
  - Now removes subheader links, as these never worked within DocuHub.
    - These would be really nice to have, but they're infeasible with our current rendering approach.
  - Added option to remove the first line of any given README.
    - Fixes duplicate titles in many NGIAB component pages, among other locations.
  - Formatting adjustments.
  
- NextGen Datastream:
  - Added most subpages from their GitHub.