### PR TITLE
Improve our handling of local test environments

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -56,7 +56,7 @@ jobs:
           echo "Building for STAGING environment"
         fi
           
-    - name: Configure baseUrl
+    - name: Configure baseUrl (staging)
       if: ${{ env.DEPLOY_ENV == 'staging' }}
       run: |
         # Create a backup of the original config
@@ -64,10 +64,27 @@ jobs:
         
         # Use sed to replace the baseUrl value
         echo "Setting baseUrl for staging"
-        sed -i 's|baseUrl: '\''\/'\''|baseUrl: '\''/docuhub-staging/'\''|g' docusaurus.config.js
-        sed -i 's|baseUrl: "\/"|baseUrl: "\/docuhub-staging\/"|g' docusaurus.config.js
-        sed -i 's|baseUrl = '\''\/'\''|baseUrl = '\''/docuhub-staging/'\''|g' docusaurus.config.js
-        sed -i 's|baseUrl = "\/"|baseUrl = "\/docuhub-staging\/"|g' docusaurus.config.js
+        sed -i 's|baseUrl: '\''\/local\/'\''|baseUrl: '\''/docuhub-staging/'\''|g' docusaurus.config.js
+        sed -i 's|baseUrl: "\/local\/"|baseUrl: "\/docuhub-staging\/"|g' docusaurus.config.js
+        sed -i 's|baseUrl = '\''\/local\/'\''|baseUrl = '\''/docuhub-staging/'\''|g' docusaurus.config.js
+        sed -i 's|baseUrl = "\/local\/"|baseUrl = "\/docuhub-staging\/"|g' docusaurus.config.js
+        
+        # Show the changed config
+        echo "Modified docusaurus.config.js:"
+        cat docusaurus.config.js
+    
+    - name: Configure baseUrl (production)
+      if: ${{ env.DEPLOY_ENV == 'production' }}
+      run: |
+        # Create a backup of the original config
+        cp docusaurus.config.js docusaurus.config.js.bak
+        
+        # Use sed to replace the baseUrl value
+        echo "Setting baseUrl for production"
+        sed -i 's|baseUrl: '\''\/local\/'\''|baseUrl: '\''/'\''|g' docusaurus.config.js
+        sed -i 's|baseUrl: "\/local\/"|baseUrl: "\/"|g' docusaurus.config.js
+        sed -i 's|baseUrl = '\''\/local\/'\''|baseUrl = '\''/'\''|g' docusaurus.config.js
+        sed -i 's|baseUrl = "\/local\/"|baseUrl = "\/"|g' docusaurus.config.js
         
         # Show the changed config
         echo "Modified docusaurus.config.js:"

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,6 @@
 import { themes as prismThemes } from "prism-react-renderer";
 
-const baseUrl = "/";
+const baseUrl = "/local/";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {


### PR DESCRIPTION
Currently, we have a running issue of things breaking in staging due to poor handling of base URLs. In the past, we've dealt with this by changing the base URL locally for validation, but this runs the risk of accidentally getting swept into the main branch alongside desirable changes.

This PR should hopefully put an end to this pitfall for good. It handles base paths as follows:
- By default, the base path for local builds of DocuHub will be `/local/`.
- When uploading to staging, this base path will be changed to `/docuhub-staging/`.
- When uploading to production, this base path will be changed to `/`.

The result of these changes is as follows:
- From the outside looking in, the production and staging environments should work exactly the same as before.
- Testing changes locally will now assume a non-default base path, making it far more obvious when something is being handled improperly.