### PR TITLE
Last-minute addition to 2i2c server image list

### DIFF
--- a/docs/services/cloudservices/2i2c/available-images.mdx
+++ b/docs/services/cloudservices/2i2c/available-images.mdx
@@ -15,6 +15,11 @@ tags: [CIROH, Services, Cloud Services, JupyterHub, 2i2c, Google Cloud, Educatio
 
 Server image configurations are options for what software environment you want your Jupyter Notebook server to run in.
 
+:::note
+This list is currently non-comprehensive and will be expanded soon.  
+For a complete listing of available server images, see [the branches of **awi-ciroh-image** on GitHub](https://github.com/CIROH-UA/awi-ciroh-image/branches).
+:::
+
 ## Pangeo Notebook base image
 
 This configuration has a general set of pre-installed libraries and tools commonly used in geoscience for tasks such as data analysis and mapping. It allows users to run workflows directly from JupyterHub without the need to install software or manage dependencies. This base image serves as a starting point; users can run it as-is for general analysis or build on it with additional packages tailored to hydrology, climate science, and beyond.


### PR DESCRIPTION
Added this (i) note at the top of Server Image Configurations.

<img width="1256" height="433" alt="image" src="https://github.com/user-attachments/assets/256eb868-1483-447a-a3c2-3f5d1895350a" />