### PR TITLE
DatastreamCLI: re-add README

### DIFF
--- a/docs/products/research-datastream/datastreamcli/index.mdx
+++ b/docs/products/research-datastream/datastreamcli/index.mdx
@@ -5,6 +5,12 @@ description: "The software backend of the Research Datastream."
 tags: [Products, CIROH, NGIAB, NextGen Datastream, National Water Model]
 ---
 
+import GitHubReadme from '@site/src/components/GitHubReadme';
+
+<GitHubReadme username="CIROH-UA" repo="datastreamCLI" trimTitle="false"/>
+
+---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />


### PR DESCRIPTION
Small correction to #495, which omitted the README from the page for DatastreamCLI. This PR re-adds that.