### PR TITLE
[CI fix] Regenerate lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,22 +37,16 @@
       },
       "engines": {
         "node": "^22.0.0"
-        "node": "^22.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.3.tgz",
-      "integrity": "sha512-/vCoMKtod+A74/BbkWsaAflWKz1ovhX5lmJpIaXQXtd6gyexZncjotBTbFM8rVJT9LKJ/Kx7iVVo3vh+KT+IJg==",
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.3.tgz",
-      "integrity": "sha512-/vCoMKtod+A74/BbkWsaAflWKz1ovhX5lmJpIaXQXtd6gyexZncjotBTbFM8rVJT9LKJ/Kx7iVVo3vh+KT+IJg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.5.tgz",
+      "integrity": "sha512-5TTDSl0USWY6YGnb4QmJGplFZhk+p9OT7hZevAaER6OGiZ17LB1GypsGYDpNo/MiVMklk8kX4gk6p1/R/EiJ8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.14",
-        "@vercel/oidc": "3.0.3"
-        "@ai-sdk/provider-utils": "3.0.14",
+        "@ai-sdk/provider-utils": "3.0.15",
         "@vercel/oidc": "3.0.3"
       },
       "engines": {
@@ -75,14 +69,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.14.tgz",
-      "integrity": "sha512-CYRU6L7IlR7KslSBVxvlqlybQvXJln/PI57O8swhOaDIURZbjRP2AY3igKgUsrmWqqnFFUHP+AwTN8xqJAknnA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.15.tgz",
+      "integrity": "sha512-kOc6Pxb7CsRlNt+sLZKL7/VGQUd7ccl3/tIK+Bqf5/QhHR0Qm3qRBMz1IwU1RmjJEZA73x+KB5cUckbDl2WF7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
         "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.5"
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -92,13 +86,13 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "2.0.82",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.82.tgz",
-      "integrity": "sha512-InaGqykKGFq/XA6Vhh2Hyy38nzeMpqp8eWxjTNEQA5Gwcal0BVNuZyTbTIL5t5VNXV+pQPDhe9ak1+mc9qxjog==",
+      "version": "2.0.85",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.85.tgz",
+      "integrity": "sha512-wK9oLn+JuFhe4QhA5Y2vnmjyJs/qYskExcvPwrmRccxMw72tL3B3LbZsKPc5i8OQbDwlJKC/FgTo336bJF40Xg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "3.0.14",
-        "ai": "5.0.82",
+        "@ai-sdk/provider-utils": "3.0.15",
+        "ai": "5.0.85",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -116,15 +110,15 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.7.0.tgz",
-      "integrity": "sha512-hOEItTFOvNLI6QX6TSGu7VE4XcUcdoKZT8NwDY+5mWwu87rGhkjlY7uesKTInlg6Sh8cyRkDBYRumxbkoBbBhA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.8.0.tgz",
+      "integrity": "sha512-Hb4BkGNnvgCj3F9XzqjiFTpA5IGkjOXwGAOV13qtc27l2qNF8X9rzSp1H5hu8XewlC0DzYtQtZZIOYzRZDyuXg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -163,99 +157,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.41.0.tgz",
-      "integrity": "sha512-iRuvbEyuHCAhIMkyzG3tfINLxTS7mSKo7q8mQF+FbQpWenlAlrXnfZTN19LRwnVjx0UtAdZq96ThMWGS6cQ61A==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.42.0.tgz",
+      "integrity": "sha512-JLyyG7bb7XOda+w/sp8ch7rEVy6LnWs3qtxr6VJJ2XIINqGsY6U+0L3aJ6QFliBRNUeEAr2QBDxSm8u9Sal5uA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.41.0.tgz",
-      "integrity": "sha512-OIPVbGfx/AO8l1V70xYTPSeTt/GCXPEl6vQICLAXLCk9WOUbcLGcy6t8qv0rO7Z7/M/h9afY6Af8JcnI+FBFdQ==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.42.0.tgz",
+      "integrity": "sha512-SkCrvtZpdSWjNq9NGu/TtOg4TbzRuUToXlQqV6lLePa2s/WQlEyFw7QYjrz4itprWG9ASuH+StDlq7n49F2sBA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.41.0.tgz",
-      "integrity": "sha512-8Mc9niJvfuO8dudWN5vSUlYkz7U3M3X3m1crDLc9N7FZrIVoNGOUETPk3TTHviJIh9y6eKZKbq1hPGoGY9fqPA==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.42.0.tgz",
+      "integrity": "sha512-6iiFbm2tRn6B2OqFv9XDTcw5LdWPudiJWIbRk+fsTX+hkPrPm4e1/SbU+lEYBciPoaTShLkDbRge4UePEyCPMQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.41.0.tgz",
-      "integrity": "sha512-vXzvCGZS6Ixxn+WyzGUVDeR3HO/QO5POeeWy1kjNJbEf6f+tZSI+OiIU9Ha+T3ntV8oXFyBEuweygw4OLmgfiQ==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.42.0.tgz",
+      "integrity": "sha512-iEokmw2k6FBa8g/TT7ClyEriaP/FUEmz3iczRoCklEHWSgoABMkaeYrxRXrA2yx76AN+gyZoC8FX0iCJ55dsOg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.41.0.tgz",
-      "integrity": "sha512-tkymXhmlcc7w/HEvLRiHcpHxLFcUB+0PnE9FcG6hfFZ1ZXiWabH+sX+uukCVnluyhfysU9HRU2kUmUWfucx1Dg==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.42.0.tgz",
+      "integrity": "sha512-ivVniRqX2ARd+jGvRHTxpWeOtO9VT+rK+OmiuRgkSunoTyxk0vjeDO7QkU7+lzBOXiYgakNjkZrBtIpW9c+muw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.41.0.tgz",
-      "integrity": "sha512-vyXDoz3kEZnosNeVQQwf0PbBt5IZJoHkozKRIsYfEVm+ylwSDFCW08qy2YIVSHdKy69/rWN6Ue/6W29GgVlmKQ==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.42.0.tgz",
+      "integrity": "sha512-9+BIw6rerUfA+eLMIS2lF4mgoeBGTCIHiqb35PLn3699Rm3CaJXz03hChdwAWcA6SwGw0haYXYJa7LF0xI6EpA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.41.0.tgz",
-      "integrity": "sha512-G9I2atg1ShtFp0t7zwleP6aPS4DcZvsV4uoQOripp16aR6VJzbEnKFPLW4OFXzX7avgZSpYeBAS+Zx4FOgmpPw==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.42.0.tgz",
+      "integrity": "sha512-NZR7yyHj2WzK6D5X8gn+/KOxPdzYEXOqVdSaK/biU8QfYUpUuEA0sCWg/XlO05tPVEcJelF/oLrrNY3UjRbOww==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -268,81 +262,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.41.0.tgz",
-      "integrity": "sha512-sxU/ggHbZtmrYzTkueTXXNyifn+ozsLP+Wi9S2hOBVhNWPZ8uRiDTDcFyL7cpCs1q72HxPuhzTP5vn4sUl74cQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.42.0.tgz",
+      "integrity": "sha512-MBkjRymf4BT6VOvMpJlg6kq8K+PkH9q+N+K4YMNdzTXlL40YwOa1wIWQ5LxP/Jhlz64kW5g9/oaMWY06Sy9dcw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.41.0.tgz",
-      "integrity": "sha512-UQ86R6ixraHUpd0hn4vjgTHbViNO8+wA979gJmSIsRI3yli2v89QSFF/9pPcADR6PbtSio/99PmSNxhZy+CR3Q==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.42.0.tgz",
+      "integrity": "sha512-kmLs7YfjT4cpr4FnhhRmnoSX4psh9KYZ9NAiWt/YcUV33m0B/Os5L4QId30zVXkOqAPAEpV5VbDPWep+/aoJdQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.41.0.tgz",
-      "integrity": "sha512-DxP9P8jJ8whJOnvmyA5mf1wv14jPuI0L25itGfOHSU6d4ZAjduVfPjTS3ROuUN5CJoTdlidYZE+DtfWHxJwyzQ==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.42.0.tgz",
+      "integrity": "sha512-U5yZ8+Jj+A4ZC0IMfElpPcddQ9NCoawD1dKyWmjHP49nzN2Z4284IFVMAJWR6fq/0ddGf4OMjjYO9cnF8L+5tw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/client-common": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.41.0.tgz",
-      "integrity": "sha512-C21J+LYkE48fDwtLX7YXZd2Fn7Fe0/DOEtvohSfr/ODP8dGDhy9faaYeWB0n1AvmZltugjkjAXT7xk0CYNIXsQ==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.42.0.tgz",
+      "integrity": "sha512-EbuxgteaYBlKgc2Fs3JzoPIKAIaevAIwmv1F+fakaEXeibG4pkmVNsyTUjpOZIgJ1kXeqNvDrcjRb6g3vYBJ9A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0"
+        "@algolia/client-common": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.41.0.tgz",
-      "integrity": "sha512-FhJy/+QJhMx1Hajf2LL8og4J7SqOAHiAuUXq27cct4QnPhSIuIGROzeRpfDNH5BUbq22UlMuGd44SeD4HRAqvA==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.42.0.tgz",
+      "integrity": "sha512-4vnFvY5Q8QZL9eDNkywFLsk/eQCRBXCBpE8HWs8iUsFNHYoamiOxAeYMin0W/nszQj6abc+jNxMChHmejO+ftQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0"
+        "@algolia/client-common": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.41.0.tgz",
-      "integrity": "sha512-tYv3rGbhBS0eZ5D8oCgV88iuWILROiemk+tQ3YsAKZv2J4kKUNvKkrX/If/SreRy4MGP2uJzMlyKcfSfO2mrsQ==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.42.0.tgz",
+      "integrity": "sha512-gkLNpU+b1pCIwk1hKTJz2NWQPT8gsfGhQasnZ5QVv4jd79fKRL/1ikd86P0AzuIQs9tbbhlMwxsSTyJmlq502w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.41.0"
+        "@algolia/client-common": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -3770,9 +3764,6 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
       "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
-      "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/logger": "3.9.2",
@@ -4791,62 +4782,56 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.0.tgz",
-      "integrity": "sha512-Woonm8ehyVIUPXChmbu80Zj6uJkC0dD9SJUZ/wOPtO8iiz/m+dkrOugAuKgoiR6qH4F+yorWila954tBz4uKsQ==",
-      "devOptional": true,
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.21.2.tgz",
+      "integrity": "sha512-mGbPAAApgjmQUl4J7WAt20aV04a26TyS21GDEpOGXFEQG5FqmZnSJ6FqB8K19HgTKioBT1+fF/Ctl5bGGao/EA==",
       "license": "MIT"
     },
     "node_modules/@module-federation/runtime": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.18.0.tgz",
-      "integrity": "sha512-+C4YtoSztM7nHwNyZl6dQKGUVJdsPrUdaf3HIKReg/GQbrt9uvOlUWo2NXMZ8vDAnf/QRrpSYAwXHmWDn9Obaw==",
-      "devOptional": true,
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.21.2.tgz",
+      "integrity": "sha512-97jlOx4RAnAHMBTfgU5FBK6+V/pfT6GNX0YjSf8G+uJ3lFy74Y6kg/BevEkChTGw5waCLAkw/pw4LmntYcNN7g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.18.0",
-        "@module-federation/runtime-core": "0.18.0",
-        "@module-federation/sdk": "0.18.0"
+        "@module-federation/error-codes": "0.21.2",
+        "@module-federation/runtime-core": "0.21.2",
+        "@module-federation/sdk": "0.21.2"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.18.0.tgz",
-      "integrity": "sha512-ZyYhrDyVAhUzriOsVfgL6vwd+5ebYm595Y13KeMf6TKDRoUHBMTLGQ8WM4TDj8JNsy7LigncK8C03fn97of0QQ==",
-      "devOptional": true,
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.21.2.tgz",
+      "integrity": "sha512-LtDnccPxjR8Xqa3daRYr1cH/6vUzK3mQSzgvnfsUm1fXte5syX4ftWw3Eu55VdqNY3yREFRn77AXdu9PfPEZRw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.18.0",
-        "@module-federation/sdk": "0.18.0"
+        "@module-federation/error-codes": "0.21.2",
+        "@module-federation/sdk": "0.21.2"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.18.0.tgz",
-      "integrity": "sha512-fSga9o4t1UfXNV/Kh6qFvRyZpPp3EHSPRISNeyT8ZoTpzDNiYzhtw0BPUSSD8m6C6XQh2s/11rI4g80UY+d+hA==",
-      "devOptional": true,
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.21.2.tgz",
+      "integrity": "sha512-SgG9NWTYGNYcHSd5MepO3AXf6DNXriIo4sKKM4mu4RqfYhHyP+yNjnF/gvYJl52VD61g0nADmzLWzBqxOqk2tg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.18.0",
-        "@module-federation/webpack-bundler-runtime": "0.18.0"
+        "@module-federation/runtime": "0.21.2",
+        "@module-federation/webpack-bundler-runtime": "0.21.2"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.18.0.tgz",
-      "integrity": "sha512-Lo/Feq73tO2unjmpRfyyoUkTVoejhItXOk/h5C+4cistnHbTV8XHrW/13fD5e1Iu60heVdAhhelJd6F898Ve9A==",
-      "devOptional": true,
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.21.2.tgz",
+      "integrity": "sha512-t2vHSJ1a9zjg7LLJoEghcytNLzeFCqOat5TbXTav5dgU0xXw82Cf0EfLrxiJL6uUpgbtyvUdqqa2DVAvMPjiiA==",
       "license": "MIT"
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.18.0.tgz",
-      "integrity": "sha512-TEvErbF+YQ+6IFimhUYKK3a5wapD90d90sLsNpcu2kB3QGT7t4nIluE25duXuZDVUKLz86tEPrza/oaaCWTpvQ==",
-      "devOptional": true,
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.21.2.tgz",
+      "integrity": "sha512-06R/NDY6Uh5RBIaBOFwYWzJCf1dIiQd/DFHToBVhejUT3ZFG7GzHEPIIsAGqMzne/JSmVsvjlXiJu7UthQ6rFA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.18.0",
-        "@module-federation/sdk": "0.18.0"
+        "@module-federation/runtime": "0.21.2",
+        "@module-federation/sdk": "0.21.2"
       }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
@@ -5181,28 +5166,27 @@
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.8.tgz",
-      "integrity": "sha512-/91CzhRl9r5BIQCgGsS7jA6MDbw1I2BQpbfcUUdkdKl2P79K3Zo/Mw/TvKzS86catwLaUQEgkGRmYawOfPg7ow==",
-      "devOptional": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.6.0.tgz",
+      "integrity": "sha512-RqlCjvWg/LkJjHpsbI48ebo2SYpIBJsV1eh9SEMfXo1batAPvB5grhAbLX0MRUOtzuQOnZMCDGdr2v7l2L8Siw==",
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.5.8",
-        "@rspack/binding-darwin-x64": "1.5.8",
-        "@rspack/binding-linux-arm64-gnu": "1.5.8",
-        "@rspack/binding-linux-arm64-musl": "1.5.8",
-        "@rspack/binding-linux-x64-gnu": "1.5.8",
-        "@rspack/binding-linux-x64-musl": "1.5.8",
-        "@rspack/binding-wasm32-wasi": "1.5.8",
-        "@rspack/binding-win32-arm64-msvc": "1.5.8",
-        "@rspack/binding-win32-ia32-msvc": "1.5.8",
-        "@rspack/binding-win32-x64-msvc": "1.5.8"
+        "@rspack/binding-darwin-arm64": "1.6.0",
+        "@rspack/binding-darwin-x64": "1.6.0",
+        "@rspack/binding-linux-arm64-gnu": "1.6.0",
+        "@rspack/binding-linux-arm64-musl": "1.6.0",
+        "@rspack/binding-linux-x64-gnu": "1.6.0",
+        "@rspack/binding-linux-x64-musl": "1.6.0",
+        "@rspack/binding-wasm32-wasi": "1.6.0",
+        "@rspack/binding-win32-arm64-msvc": "1.6.0",
+        "@rspack/binding-win32-ia32-msvc": "1.6.0",
+        "@rspack/binding-win32-x64-msvc": "1.6.0"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.8.tgz",
-      "integrity": "sha512-spJfpOSN3f7V90ic45/ET2NKB2ujAViCNmqb0iGurMNQtFRq+7Kd+jvVKKGXKBHBbsQrFhidSWbbqy2PBPGK8g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.6.0.tgz",
+      "integrity": "sha512-IrigOWnGvQgugsTZgf3dB5uko+y+lkNLYg/8w0DiobxkWhpLO97RAeR1w0ofIPXYVu3UWVf7dgHj3PjTqjC9Tw==",
       "cpu": [
         "arm64"
       ],
@@ -5213,9 +5197,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.8.tgz",
-      "integrity": "sha512-YFOzeL1IBknBcri8vjUp43dfUBylCeQnD+9O9p0wZmLAw7DtpN5JEOe2AkGo8kdTqJjYKI+cczJPKIw6lu1LWw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.6.0.tgz",
+      "integrity": "sha512-UYz+Y1XqbHGnkUOsaZRuwiuQaQaQ5rEPSboBPlIVDtblwmB71yxo3ET0nSoUhz8L/WXqQoARiraTCxUP6bvSIg==",
       "cpu": [
         "x64"
       ],
@@ -5226,9 +5210,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.8.tgz",
-      "integrity": "sha512-UAWCsOnpkvy8eAVRo0uipbHXDhnoDq5zmqWTMhpga0/a3yzCp2e+fnjZb/qnFNYb5MeL0O1mwMOYgn1M3oHILQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.6.0.tgz",
+      "integrity": "sha512-Jr7aaxrtwOnh7ge7tZP+Mjpo6uNltvQisL25WcjpP+8PnPT0C9jziKDJso7KxeOINXnQ2yRn2h65+HBNb7FQig==",
       "cpu": [
         "arm64"
       ],
@@ -5239,9 +5223,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.8.tgz",
-      "integrity": "sha512-GnSvGT4GjokPSD45cTtE+g7LgghuxSP1MRmvd+Vp/I8pnxTVSTsebRod4TAqyiv+l11nuS8yqNveK9qiOkBLWw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.6.0.tgz",
+      "integrity": "sha512-hl17reUhkjgkcLao6ZvNiSRQFGFykqUpIj1//v/XtVd/2XAZ0Kt7jv9UUeaR+2zY8piH+tgCkwgefmjmajMeFg==",
       "cpu": [
         "arm64"
       ],
@@ -5252,9 +5236,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.8.tgz",
-      "integrity": "sha512-XLxh5n/pzUfxsugz/8rVBv+Tx2nqEM+9rharK69kfooDsQNKyz7PANllBQ/v4svJ+W0BRHnDL4qXSGdteZeEjA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.6.0.tgz",
+      "integrity": "sha512-xdlb+ToerFU/YggndCfIrZI/S/C80CP9ZFw6lhnEFSTJDAG88KptxstsoKUh8YzyPTD45CYaOjYNtUtiv0nScg==",
       "cpu": [
         "x64"
       ],
@@ -5265,9 +5249,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.8.tgz",
-      "integrity": "sha512-gE0+MZmwF+01p9/svpEESkzkLpBkVUG2o03YMpwXYC/maeRRhWvF8BJ7R3i/Ls/jFGSE87dKX5NbRLVzqksq/w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.6.0.tgz",
+      "integrity": "sha512-IkXEW/FBPPz4EJJTLNZvA+94aLaW2HgUMYu7zCIw5YMc9JJ/UXexY1zjX/A7yidsCiZCRy/ZrB+veFJ5FkZv7w==",
       "cpu": [
         "x64"
       ],
@@ -5278,22 +5262,22 @@
       ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.8.tgz",
-      "integrity": "sha512-cfg3niNHeJuxuml1Vy9VvaJrI/5TakzoaZvKX2g5S24wfzR50Eyy4JAsZ+L2voWQQp1yMJbmPYPmnTCTxdJQBQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.6.0.tgz",
+      "integrity": "sha512-XGwX35XXnoTYVUGwDBsKNOkkk/yUsT/RF59u9BwT3QBM5eSXk767xVw/ZeiiyJf5YfI/52HDW2E4QZyvlYyv7g==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.5"
+        "@napi-rs/wasm-runtime": "1.0.7"
       }
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.8.tgz",
-      "integrity": "sha512-7i3ZTHFXKfU/9Jm9XhpMkrdkxO7lfeYMNVEGkuU5dyBfRMQj69dRgPL7zJwc2plXiqu9LUOl+TwDNTjap7Q36g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.6.0.tgz",
+      "integrity": "sha512-HOA/U7YC6EB74CpIrT2GrvPgd+TLr0anNuOp/8omw9hH1jjsP5cjUMgWeAGmWyXWxwoS8rRJ0xhRA+UIe3cL3g==",
       "cpu": [
         "arm64"
       ],
@@ -5304,9 +5288,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.8.tgz",
-      "integrity": "sha512-7ZPPWO11J+soea1+mnfaPpQt7GIodBM7A86dx6PbXgVEoZmetcWPrCF2NBfXxQWOKJ9L3RYltC4z+ZyXRgMOrw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.6.0.tgz",
+      "integrity": "sha512-ThczdltBOFcq+IrTflCE+8q0GvKoISt6pTupkuGnI1/bCnqhCxPP6kx8Z06fdJUFMhvBtpZa0gDJvhh3JBZrKA==",
       "cpu": [
         "ia32"
       ],
@@ -5317,9 +5301,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.8.tgz",
-      "integrity": "sha512-N/zXQgzIxME3YUzXT8qnyzxjqcnXudWOeDh8CAG9zqTCnCiy16SFfQ/cQgEoLlD9geQntV6jx2GbDDI5kpDGMQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.6.0.tgz",
+      "integrity": "sha512-Bhyvsh1m6kIpr1vqZlcdUDUTh0bheRe9SF+f6jw0kPDPbh8FfrRbshPKmRHpRZAUHt20NqgUKR2z2BaKb0IJvQ==",
       "cpu": [
         "x64"
       ],
@@ -5330,14 +5314,13 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.8.tgz",
-      "integrity": "sha512-sUd2LfiDhqYVfvknuoz0+/c+wSpn693xotnG5g1CSWKZArbtwiYzBIVnNlcHGmuoBRsnj/TkSq8dTQ7gwfBroQ==",
-      "devOptional": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-u2GDSToEhmgIsy0QbOPA81i9tu87J2HgSsRA3HHZfWIR8Vt8KdlAriQnG8CatDnvFSY/UQEumVf5Z1HUAQwxCg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime-tools": "0.18.0",
-        "@rspack/binding": "1.5.8",
+        "@module-federation/runtime-tools": "0.21.2",
+        "@rspack/binding": "1.6.0",
         "@rspack/lite-tapable": "1.0.1"
       },
       "engines": {
@@ -5356,7 +5339,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
       "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -5877,7 +5859,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/html": {
@@ -5892,16 +5873,6 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@swc/html-darwin-arm64": "1.14.0",
-        "@swc/html-darwin-x64": "1.14.0",
-        "@swc/html-linux-arm-gnueabihf": "1.14.0",
-        "@swc/html-linux-arm64-gnu": "1.14.0",
-        "@swc/html-linux-arm64-musl": "1.14.0",
-        "@swc/html-linux-x64-gnu": "1.14.0",
-        "@swc/html-linux-x64-musl": "1.14.0",
-        "@swc/html-win32-arm64-msvc": "1.14.0",
-        "@swc/html-win32-ia32-msvc": "1.14.0",
-        "@swc/html-win32-x64-msvc": "1.14.0"
         "@swc/html-darwin-arm64": "1.14.0",
         "@swc/html-darwin-x64": "1.14.0",
         "@swc/html-linux-arm-gnueabihf": "1.14.0",
@@ -6078,7 +6049,6 @@
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -6789,14 +6759,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.82",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.82.tgz",
-      "integrity": "sha512-wmZZfsU40qB77umrcj3YzMSk6cUP5gxLXZDPfiSQLBLegTVXPUdSJC603tR7JB5JkhBDzN5VLaliuRKQGKpUXg==",
+      "version": "5.0.85",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.85.tgz",
+      "integrity": "sha512-7aB4e0uJWpC+em2U9Q59UsmvQIab0d46Un6E9b4Y5gdhu7PNov3bGsnuVk2sfCTJSn+uNncB84BWRC2NkmSCMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.3",
+        "@ai-sdk/gateway": "2.0.5",
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.14",
+        "@ai-sdk/provider-utils": "3.0.15",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -6871,25 +6841,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.41.0.tgz",
-      "integrity": "sha512-9E4b3rJmYbBkn7e3aAPt1as+VVnRhsR4qwRRgOzpeyz4PAOuwKh0HI4AN6mTrqK0S0M9fCCSTOUnuJ8gPY/tvA==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.42.0.tgz",
+      "integrity": "sha512-X5+PtWc9EJIPafT/cj8ZG+6IU3cjRRnlHGtqMHK/9gsiupQbAyYlH5y7qt/FtsAhfX5AICHffZy69ZAsVrxWkQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.7.0",
-        "@algolia/client-abtesting": "5.41.0",
-        "@algolia/client-analytics": "5.41.0",
-        "@algolia/client-common": "5.41.0",
-        "@algolia/client-insights": "5.41.0",
-        "@algolia/client-personalization": "5.41.0",
-        "@algolia/client-query-suggestions": "5.41.0",
-        "@algolia/client-search": "5.41.0",
-        "@algolia/ingestion": "1.41.0",
-        "@algolia/monitoring": "1.41.0",
-        "@algolia/recommend": "5.41.0",
-        "@algolia/requester-browser-xhr": "5.41.0",
-        "@algolia/requester-fetch": "5.41.0",
-        "@algolia/requester-node-http": "5.41.0"
+        "@algolia/abtesting": "1.8.0",
+        "@algolia/client-abtesting": "5.42.0",
+        "@algolia/client-analytics": "5.42.0",
+        "@algolia/client-common": "5.42.0",
+        "@algolia/client-insights": "5.42.0",
+        "@algolia/client-personalization": "5.42.0",
+        "@algolia/client-query-suggestions": "5.42.0",
+        "@algolia/client-search": "5.42.0",
+        "@algolia/ingestion": "1.42.0",
+        "@algolia/monitoring": "1.42.0",
+        "@algolia/recommend": "5.42.0",
+        "@algolia/requester-browser-xhr": "5.42.0",
+        "@algolia/requester-fetch": "5.42.0",
+        "@algolia/requester-node-http": "5.42.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -10148,9 +10118,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.21.tgz",
-      "integrity": "sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==",
+      "version": "2.8.22",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.22.tgz",
+      "integrity": "sha512-/tk9kky/d8T8CTXIQYASLyhAxR5VwL3zct1oAoVTaOUHwrmsGnfbRwNdEq+vOl2BN8i3PcDdP0o4Q+jjKQoFbQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -11397,9 +11367,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001751",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
-      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "version": "1.0.30001752",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001752.tgz",
+      "integrity": "sha512-vKUk7beoukxE47P5gcVNKkDRzXdVofotshHwfR9vmpeFKxmI5PBpgOMC18LUJUA/DvJ70Y7RveasIBraqsyO/g==",
       "funding": [
         {
           "type": "opencollective",
@@ -15762,9 +15732,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.243",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.243.tgz",
-      "integrity": "sha512-ZCphxFW3Q1TVhcgS9blfut1PX8lusVi2SvXQgmEEnK4TCmE1JhH2JkjJN+DNt0pJJwfBri5AROBnz2b/C+YU9g==",
+      "version": "1.5.244",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
+      "integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -23429,7 +23399,6 @@
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
-      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -35754,7 +35723,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.6.tgz",
       "integrity": "sha512-9Zi9UP2YmDpgmQVbyOPJClY0dwf58JDyDMQ7uRc4krmc72twNI2fvlBWHLqVekBpPc7h5NJkGVT1zNDxFrqhvg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@swc/counter": "^0.1.3"


### PR DESCRIPTION
Given the `package-lock.json` issues posed by #483, #492, and #496, we've now hit a merge conflict that's rendered the lockfile unreadable. This PR regenerates the lockfile, which should hopefully address this problem for good.