### PR TITLE
Add collapsing element to code block

### DIFF
--- a/docs/products/data-management/dataaccess/index.mdx
+++ b/docs/products/data-management/dataaccess/index.mdx
@@ -67,7 +67,10 @@ The AWS retrospective resource is the primary publicly available source for the 
 
 Jupyter notebook instructions for processing NWM Zarr and NetCDF output formats [here](https://github.com/CIROH-UA/data_access_example/)
 
-An example of pulling data from the channel output zarr 2.1 archive and writing the results to csv follows:
+
+<details>
+<summary> Click to see an example of pulling data from the channel output zarr 2.1 archive and writing the results to csv. </summary>
+ <br />
 
 ```py
 '''
@@ -123,6 +126,8 @@ dan.ames@byu.edu
 '''
 
 ```
+</details>
+
 
 #### Google – Operational NWM Data
 


### PR DESCRIPTION
Wanted to improve the flow of reading for the average user who is just learning about the national water model and data access. Focused on making the transition from the code example to reading about other data hosting sites smoother by "hiding" the code block in a collapsing section. 

## Additions
-Added HTML tags to create the collapsing section on this page. docs/products/data-management/dataaccess/index.mdx
-The tags are on lines 71, 72, 73, and 128 


## Removals
-N/A

## Changes

-None of the actual text is changed in this update, just adding the formatting by adding the collapsing section. 

## Testing

## Screenshots
Showing menu open...
<img width="1440" height="900" alt="Code Block Open" src="https://github.com/user-attachments/assets/c834d95f-822d-401d-bac0-af819c5876f8" />

Showing the menu closed...
<img width="1440" height="900" alt="Code Block Closed" src="https://github.com/user-attachments/assets/94290cf0-e2e2-465f-aa7b-9e91b543a07c" />

## Notes

-I'm new at making contributions to CIROH. Any guidance on how these are typically formatted would be greatly appreciated. 

## Todos



## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other
These don't appear to be applicable. 
- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
